### PR TITLE
🎨 Palette: Add accessibility labels to action bar buttons

### DIFF
--- a/components/ReplyDrawer/components/ActionBar.test.tsx
+++ b/components/ReplyDrawer/components/ActionBar.test.tsx
@@ -1,0 +1,29 @@
+import { render } from '@testing-library/react-native';
+import ActionBar from './ActionBar';
+
+jest.mock('../../../hooks/useTheme', () => ({
+  useTheme: () => ({ backgroundColor: '#fff', textColor: '#000' }),
+}));
+
+jest.mock('../../../context/AppContext', () => ({
+  useAppContext: () => ({
+    instanceInfo: {
+      configuration: { statuses: { max_media_attachments: 4 } },
+    },
+  }),
+}));
+
+describe('ActionBar Accessibility', () => {
+  it('renders action buttons with appropriate accessibility labels', () => {
+    const { getByLabelText } = render(
+      <ActionBar onImageSelect={() => {}} selectedImages={[]} openPoll={() => {}} />
+    );
+
+    expect(getByLabelText('Add image')).toBeTruthy();
+    expect(getByLabelText('Add GIF')).toBeTruthy();
+    expect(getByLabelText('Add Mention')).toBeTruthy();
+    expect(getByLabelText('Add Hashtag')).toBeTruthy();
+    expect(getByLabelText('Toggle Content Warning')).toBeTruthy();
+    expect(getByLabelText('Create poll')).toBeTruthy();
+  });
+});

--- a/components/ReplyDrawer/components/ActionBar.tsx
+++ b/components/ReplyDrawer/components/ActionBar.tsx
@@ -58,30 +58,38 @@ const ActionBar: React.FC<ActionBarProps> = ({
         { backgroundColor: theme.backgroundColor },
       ]}
     >
-      <TouchableOpacity style={styles.actionButton} onPress={handleImagePicker}>
+      <TouchableOpacity style={styles.actionButton} onPress={handleImagePicker} accessibilityLabel="Add image" accessibilityRole="button">
         <CustomIcon name="PhotoIcon" size={24} color={theme.textColor} />
       </TouchableOpacity>
       <TouchableOpacity
         style={styles.actionButton}
         onPress={() => console.log("Add GIF")}
+        accessibilityLabel="Add GIF"
+        accessibilityRole="button"
       >
         <PugText style={{ color: theme.textColor }}>GIF</PugText>
       </TouchableOpacity>
       <TouchableOpacity
         style={styles.actionButton}
         onPress={() => console.log("Add Mention")}
+        accessibilityLabel="Add Mention"
+        accessibilityRole="button"
       >
         <CustomIcon name="AtSymbolIcon" size={24} color={theme.textColor} />
       </TouchableOpacity>
       <TouchableOpacity
         style={styles.actionButton}
         onPress={() => console.log("Add Hashtag")}
+        accessibilityLabel="Add Hashtag"
+        accessibilityRole="button"
       >
         <CustomIcon name="HashtagIcon" size={24} color={theme.textColor} />
       </TouchableOpacity>
       <TouchableOpacity
         style={styles.actionButton}
         onPress={() => console.log("Toggle Content Warning")}
+        accessibilityLabel="Toggle Content Warning"
+        accessibilityRole="button"
       >
         <CustomIcon
           name="ExclamationTriangleIcon"
@@ -89,7 +97,7 @@ const ActionBar: React.FC<ActionBarProps> = ({
           color={theme.textColor}
         />
       </TouchableOpacity>
-      <TouchableOpacity style={styles.actionButton} onPress={openPoll}>
+      <TouchableOpacity style={styles.actionButton} onPress={openPoll} accessibilityLabel="Create poll" accessibilityRole="button">
         <CustomIcon name="ChartBarIcon" size={24} color={theme.textColor} />
       </TouchableOpacity>
     </View>

--- a/components/StatusActionBar/StatusActionBar.test.tsx
+++ b/components/StatusActionBar/StatusActionBar.test.tsx
@@ -1,0 +1,27 @@
+import { render } from '@testing-library/react-native';
+import StatusActionBar from './StatusActionBar';
+
+// Mock the context and hooks if necessary
+jest.mock('../../hooks/useMastodonAPI', () => ({
+  useMastodonAPI: () => ({
+    favoriteStatus: jest.fn(),
+    reblogStatus: jest.fn(),
+    bookmarkStatus: jest.fn(),
+    loading: false,
+    error: null,
+  }),
+}));
+
+describe('StatusActionBar Accessibility', () => {
+  it('renders buttons with appropriate accessibility labels', () => {
+    const { getByLabelText } = render(
+      <StatusActionBar statusId="123" onReplyPress={() => {}} />
+    );
+
+    expect(getByLabelText('Reply')).toBeTruthy();
+    expect(getByLabelText('Favorite')).toBeTruthy();
+    expect(getByLabelText('Reblog')).toBeTruthy();
+    expect(getByLabelText('Bookmark')).toBeTruthy();
+    expect(getByLabelText('More options')).toBeTruthy();
+  });
+});

--- a/components/StatusActionBar/StatusActionBar.tsx
+++ b/components/StatusActionBar/StatusActionBar.tsx
@@ -50,6 +50,8 @@ const StatusActionBar: React.FC<StatusActionBarProps> = ({
           <TouchableOpacity
             onPress={() => onReplyPress(statusId)}
             style={styles.icon}
+            accessibilityLabel="Reply"
+            accessibilityRole="button"
           >
             <CustomIcon
               name="ChatBubbleOvalLeftIcon"
@@ -57,7 +59,7 @@ const StatusActionBar: React.FC<StatusActionBarProps> = ({
               color={"#aaa"}
             />
           </TouchableOpacity>
-          <TouchableOpacity onPress={handleFavorite} style={styles.icon}>
+          <TouchableOpacity onPress={handleFavorite} style={styles.icon} accessibilityLabel={isFavorited ? "Unfavorite" : "Favorite"} accessibilityRole="button">
             <CustomIcon
               name="HeartIcon"
               solid={isFavorited}
@@ -65,7 +67,7 @@ const StatusActionBar: React.FC<StatusActionBarProps> = ({
               color={isFavorited ? "#E0245E" : "#aaa"}
             />
           </TouchableOpacity>
-          <TouchableOpacity onPress={handleReblog} style={styles.icon}>
+          <TouchableOpacity onPress={handleReblog} style={styles.icon} accessibilityLabel={isReblogged ? "Undo reblog" : "Reblog"} accessibilityRole="button">
             <CustomIcon
               name="ArrowPathIcon"
               solid={isReblogged}
@@ -73,7 +75,7 @@ const StatusActionBar: React.FC<StatusActionBarProps> = ({
               color={isReblogged ? "#1DA1F2" : "#aaa"}
             />
           </TouchableOpacity>
-          <TouchableOpacity onPress={handleBookmark}>
+          <TouchableOpacity onPress={handleBookmark} accessibilityLabel={isBookmarked ? "Remove bookmark" : "Bookmark"} accessibilityRole="button">
             <CustomIcon
               name="BookmarkIcon"
               solid={isBookmarked}
@@ -82,7 +84,7 @@ const StatusActionBar: React.FC<StatusActionBarProps> = ({
             />
           </TouchableOpacity>
         </View>
-        <TouchableOpacity onPress={() => console.log("More options pressed")}>
+        <TouchableOpacity onPress={() => console.log("More options pressed")} accessibilityLabel="More options" accessibilityRole="button">
           <CustomIcon name="EllipsisHorizontalIcon" size={22} color="#aaa" />
         </TouchableOpacity>
       </View>


### PR DESCRIPTION
🎨 Palette: Add accessibility labels to action bar buttons

💡 What: Added `accessibilityLabel` and `accessibilityRole="button"` attributes to all icon-only buttons in the `StatusActionBar` and reply `ActionBar` components.
🎯 Why: Icon-only buttons without accessible labels are invisible to screen readers, making core actions like Reply, Favorite, and Adding Media inaccessible to users relying on assistive technologies.
♿ Accessibility: Improved screen reader support for key post interactions. Also added dynamic labels for toggle states (e.g., changing from "Favorite" to "Unfavorite").

---
*PR created automatically by Jules for task [12100958079144540248](https://jules.google.com/task/12100958079144540248) started by @cajuuh*