### PR TITLE
🎨 Palette: Add ARIA labels to StatusActionBar icons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,1 @@
+## 2024-03-24 - Add ARIA Labels to StatusActionBar Icons\n**Learning:** Icon-only buttons in React Native require accessibilityLabel, accessibilityRole, and accessibilityState (like checked or selected) to be usable by screen readers.\n**Action:** Add accessibility props to TouchableOpacity components wrapping icons, particularly in action bars.

--- a/components/StatusActionBar/StatusActionBar.tsx
+++ b/components/StatusActionBar/StatusActionBar.tsx
@@ -50,6 +50,9 @@ const StatusActionBar: React.FC<StatusActionBarProps> = ({
           <TouchableOpacity
             onPress={() => onReplyPress(statusId)}
             style={styles.icon}
+            accessibilityRole="button"
+            accessibilityLabel="Reply"
+            accessibilityHint="Replies to this status"
           >
             <CustomIcon
               name="ChatBubbleOvalLeftIcon"
@@ -57,7 +60,14 @@ const StatusActionBar: React.FC<StatusActionBarProps> = ({
               color={"#aaa"}
             />
           </TouchableOpacity>
-          <TouchableOpacity onPress={handleFavorite} style={styles.icon}>
+          <TouchableOpacity
+            onPress={handleFavorite}
+            style={styles.icon}
+            accessibilityRole="button"
+            accessibilityLabel="Favorite"
+            accessibilityState={{ checked: isFavorited }}
+            accessibilityHint={isFavorited ? "Unfavorites this status" : "Favorites this status"}
+          >
             <CustomIcon
               name="HeartIcon"
               solid={isFavorited}
@@ -65,7 +75,14 @@ const StatusActionBar: React.FC<StatusActionBarProps> = ({
               color={isFavorited ? "#E0245E" : "#aaa"}
             />
           </TouchableOpacity>
-          <TouchableOpacity onPress={handleReblog} style={styles.icon}>
+          <TouchableOpacity
+            onPress={handleReblog}
+            style={styles.icon}
+            accessibilityRole="button"
+            accessibilityLabel="Reblog"
+            accessibilityState={{ checked: isReblogged }}
+            accessibilityHint={isReblogged ? "Unreblogs this status" : "Reblogs this status"}
+          >
             <CustomIcon
               name="ArrowPathIcon"
               solid={isReblogged}
@@ -73,7 +90,13 @@ const StatusActionBar: React.FC<StatusActionBarProps> = ({
               color={isReblogged ? "#1DA1F2" : "#aaa"}
             />
           </TouchableOpacity>
-          <TouchableOpacity onPress={handleBookmark}>
+          <TouchableOpacity
+            onPress={handleBookmark}
+            accessibilityRole="button"
+            accessibilityLabel="Bookmark"
+            accessibilityState={{ checked: isBookmarked }}
+            accessibilityHint={isBookmarked ? "Unbookmarks this status" : "Bookmarks this status"}
+          >
             <CustomIcon
               name="BookmarkIcon"
               solid={isBookmarked}
@@ -82,7 +105,12 @@ const StatusActionBar: React.FC<StatusActionBarProps> = ({
             />
           </TouchableOpacity>
         </View>
-        <TouchableOpacity onPress={() => console.log("More options pressed")}>
+        <TouchableOpacity
+          onPress={() => console.log("More options pressed")}
+          accessibilityRole="button"
+          accessibilityLabel="More options"
+          accessibilityHint="Shows more options for this status"
+        >
           <CustomIcon name="EllipsisHorizontalIcon" size={22} color="#aaa" />
         </TouchableOpacity>
       </View>


### PR DESCRIPTION
💡 **What:** Added `accessibilityRole`, `accessibilityLabel`, `accessibilityState`, and `accessibilityHint` props to the icon-only `TouchableOpacity` components in `StatusActionBar.tsx`.
🎯 **Why:** Icon-only buttons without these props are inaccessible to screen reader users, making it impossible for them to understand what actions (Reply, Favorite, Reblog, Bookmark, More options) they are taking or what the current state is.
📸 **Before/After:** No visual changes, entirely semantic and screen-reader specific.
♿ **Accessibility:** This directly fixes accessibility barriers by ensuring keyboard navigation and screen readers correctly read out the intent and state of the Mastodon status actions. Also added a journal entry in `.Jules/palette.md` to note this learning.

---
*PR created automatically by Jules for task [12866371561325329013](https://jules.google.com/task/12866371561325329013) started by @cajuuh*