### PR TITLE
🎨 Palette: Add ARIA labels to StatusActionBar buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-15 - Missing ARIA Labels on Icon-only TouchableOpacities
+**Learning:** Found an accessibility issue pattern where `TouchableOpacity` components containing only icons (like those in `StatusActionBar`) lack explicit ARIA labels and roles, rendering them unreadable or confusing to screen reader users in this React Native app.
+**Action:** When adding new icon-only buttons, always ensure `accessibilityRole="button"` and `accessibilityLabel` are set. If the button toggles state, use `accessibilityState={{ checked: isChecked }}` or dynamically change the `accessibilityLabel`.

--- a/components/StatusActionBar/StatusActionBar.tsx
+++ b/components/StatusActionBar/StatusActionBar.tsx
@@ -50,6 +50,9 @@ const StatusActionBar: React.FC<StatusActionBarProps> = ({
           <TouchableOpacity
             onPress={() => onReplyPress(statusId)}
             style={styles.icon}
+            accessibilityRole="button"
+            accessibilityLabel="Reply"
+            accessibilityHint="Opens reply drawer"
           >
             <CustomIcon
               name="ChatBubbleOvalLeftIcon"
@@ -57,7 +60,13 @@ const StatusActionBar: React.FC<StatusActionBarProps> = ({
               color={"#aaa"}
             />
           </TouchableOpacity>
-          <TouchableOpacity onPress={handleFavorite} style={styles.icon}>
+          <TouchableOpacity
+            onPress={handleFavorite}
+            style={styles.icon}
+            accessibilityRole="button"
+            accessibilityLabel={isFavorited ? "Undo favorite" : "Favorite"}
+            accessibilityState={{ checked: isFavorited }}
+          >
             <CustomIcon
               name="HeartIcon"
               solid={isFavorited}
@@ -65,7 +74,13 @@ const StatusActionBar: React.FC<StatusActionBarProps> = ({
               color={isFavorited ? "#E0245E" : "#aaa"}
             />
           </TouchableOpacity>
-          <TouchableOpacity onPress={handleReblog} style={styles.icon}>
+          <TouchableOpacity
+            onPress={handleReblog}
+            style={styles.icon}
+            accessibilityRole="button"
+            accessibilityLabel={isReblogged ? "Undo reblog" : "Reblog"}
+            accessibilityState={{ checked: isReblogged }}
+          >
             <CustomIcon
               name="ArrowPathIcon"
               solid={isReblogged}
@@ -73,7 +88,12 @@ const StatusActionBar: React.FC<StatusActionBarProps> = ({
               color={isReblogged ? "#1DA1F2" : "#aaa"}
             />
           </TouchableOpacity>
-          <TouchableOpacity onPress={handleBookmark}>
+          <TouchableOpacity
+            onPress={handleBookmark}
+            accessibilityRole="button"
+            accessibilityLabel={isBookmarked ? "Remove bookmark" : "Bookmark"}
+            accessibilityState={{ checked: isBookmarked }}
+          >
             <CustomIcon
               name="BookmarkIcon"
               solid={isBookmarked}
@@ -82,7 +102,11 @@ const StatusActionBar: React.FC<StatusActionBarProps> = ({
             />
           </TouchableOpacity>
         </View>
-        <TouchableOpacity onPress={() => console.log("More options pressed")}>
+        <TouchableOpacity
+          onPress={() => console.log("More options pressed")}
+          accessibilityRole="button"
+          accessibilityLabel="More options"
+        >
           <CustomIcon name="EllipsisHorizontalIcon" size={22} color="#aaa" />
         </TouchableOpacity>
       </View>


### PR DESCRIPTION
💡 What: Added `accessibilityRole="button"`, `accessibilityLabel`, and dynamic `accessibilityState` (like `checked: isFavorited`) to the icon-only buttons in `StatusActionBar` (Reply, Favorite, Reblog, Bookmark, More options). Created a journal entry in `.Jules/palette.md` for this discovery.
🎯 Why: Icon-only touchables are invisible/unreadable to screen readers without these props. This ensures visually impaired users can navigate and interact with post actions intuitively.
♿ Accessibility: Major improvement. Screen readers will now correctly announce "Favorite, button, checked" instead of just "button" or ignoring the element entirely.

---
*PR created automatically by Jules for task [10022284330601777548](https://jules.google.com/task/10022284330601777548) started by @cajuuh*