### PR TITLE
🎨 Palette: StatusActionBar Accessibility Improvement

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-03-11 - Accessibility for icon-only buttons
+**Learning:** Icon-only `TouchableOpacity` components in React Native apps do not provide any context to screen readers by default. They require explicit accessibility props to be announced properly.
+**Action:** When creating icon-only buttons with `TouchableOpacity`, always add `accessibilityRole="button"`, `accessibilityLabel` (for the primary action), and relevant `accessibilityState` or `accessibilityHint` props to ensure proper screen reader compatibility.

--- a/components/StatusActionBar/StatusActionBar.tsx
+++ b/components/StatusActionBar/StatusActionBar.tsx
@@ -50,6 +50,9 @@ const StatusActionBar: React.FC<StatusActionBarProps> = ({
           <TouchableOpacity
             onPress={() => onReplyPress(statusId)}
             style={styles.icon}
+            accessibilityRole="button"
+            accessibilityLabel="Reply to status"
+            accessibilityHint="Navigates to the reply screen for this status"
           >
             <CustomIcon
               name="ChatBubbleOvalLeftIcon"
@@ -57,7 +60,14 @@ const StatusActionBar: React.FC<StatusActionBarProps> = ({
               color={"#aaa"}
             />
           </TouchableOpacity>
-          <TouchableOpacity onPress={handleFavorite} style={styles.icon}>
+          <TouchableOpacity
+            onPress={handleFavorite}
+            style={styles.icon}
+            accessibilityRole="button"
+            accessibilityLabel="Favorite status"
+            accessibilityState={{ selected: isFavorited }}
+            accessibilityHint={isFavorited ? "Removes the favorite from this status" : "Favorites this status"}
+          >
             <CustomIcon
               name="HeartIcon"
               solid={isFavorited}
@@ -65,7 +75,14 @@ const StatusActionBar: React.FC<StatusActionBarProps> = ({
               color={isFavorited ? "#E0245E" : "#aaa"}
             />
           </TouchableOpacity>
-          <TouchableOpacity onPress={handleReblog} style={styles.icon}>
+          <TouchableOpacity
+            onPress={handleReblog}
+            style={styles.icon}
+            accessibilityRole="button"
+            accessibilityLabel="Reblog status"
+            accessibilityState={{ selected: isReblogged }}
+            accessibilityHint={isReblogged ? "Removes the reblog from this status" : "Reblogs this status"}
+          >
             <CustomIcon
               name="ArrowPathIcon"
               solid={isReblogged}
@@ -73,7 +90,13 @@ const StatusActionBar: React.FC<StatusActionBarProps> = ({
               color={isReblogged ? "#1DA1F2" : "#aaa"}
             />
           </TouchableOpacity>
-          <TouchableOpacity onPress={handleBookmark}>
+          <TouchableOpacity
+            onPress={handleBookmark}
+            accessibilityRole="button"
+            accessibilityLabel="Bookmark status"
+            accessibilityState={{ selected: isBookmarked }}
+            accessibilityHint={isBookmarked ? "Removes the bookmark from this status" : "Bookmarks this status"}
+          >
             <CustomIcon
               name="BookmarkIcon"
               solid={isBookmarked}
@@ -82,7 +105,12 @@ const StatusActionBar: React.FC<StatusActionBarProps> = ({
             />
           </TouchableOpacity>
         </View>
-        <TouchableOpacity onPress={() => console.log("More options pressed")}>
+        <TouchableOpacity
+          onPress={() => console.log("More options pressed")}
+          accessibilityRole="button"
+          accessibilityLabel="More options"
+          accessibilityHint="Shows more options for this status"
+        >
           <CustomIcon name="EllipsisHorizontalIcon" size={22} color="#aaa" />
         </TouchableOpacity>
       </View>


### PR DESCRIPTION
### 💡 What
Added missing accessibility props (`accessibilityRole`, `accessibilityLabel`, `accessibilityState`, and `accessibilityHint`) to all icon-only `TouchableOpacity` components in `StatusActionBar.tsx`. Also added a journal entry in `.Jules/palette.md` detailing the required props.

### 🎯 Why
Icon-only `TouchableOpacity` components in React Native apps do not provide any context to screen readers by default. This change ensures screen readers can correctly interpret the buttons' purpose (e.g. "Reply to status", "Favorite status") and state (e.g. favorited vs not favorited).

### ♿ Accessibility
- All icon-only buttons in `StatusActionBar` now have explicit accessibility roles, labels, hints, and state (where applicable).
- Screen reader users will now be able to navigate and interact with the status actions.

---
*PR created automatically by Jules for task [16592515741702726890](https://jules.google.com/task/16592515741702726890) started by @cajuuh*